### PR TITLE
Fix E154: Duplicate tag error

### DIFF
--- a/doc/lf.txt
+++ b/doc/lf.txt
@@ -37,7 +37,7 @@ REQUIREMENTS                                            *lf-requirements*
 
 INSTALLATION                                            *lf-installation*
 
-Requires *lf* to be installed. The installation instructions for *lf* can be
+Requires lf to be installed. The installation instructions for lf can be
 found here <https://github.com/gokcehan/lf#installation>.
 
 A sample installation is given.


### PR DESCRIPTION
Remove duplicate tags `*lf*` from doc file.
It seems that in vim doc file all tags must be unique. Otherwise you'll get error like this:

```
E154: Duplicate tag "lf" in file doc/lf.txt
```

