### PR TITLE
Fix: Cannot open files with Space in its path

### DIFF
--- a/lua/lf/main.lua
+++ b/lua/lf/main.lua
@@ -182,7 +182,7 @@ function Lf:__set_cmd_wrapper()
 
     -- command lf -command '$printf $id > '"$fid"'' -last-dir-path="$tmp" "$@"
     self.term.cmd =
-        ([[%s -command='$printf $id > %s' -last-dir-path='%s' -selection-path='%s' %s]])
+        ([[%s -command='$printf $id > %s' -last-dir-path='%s' -selection-path='%s' '%s']])
         :format(self.term.cmd, self.tmp_id, self.tmp_lastdir, self.tmp_sel, open_on)
     return self
 end


### PR DESCRIPTION
I found out that Lf wouldn't open on folders whose path had the Space character, this was due to the path string not being enclosed in quotes so that it is escaped by the terminal.