### PR TITLE
Fix: Key Mappings only work on the first run instance

### DIFF
--- a/lua/lf/main.lua
+++ b/lua/lf/main.lua
@@ -225,10 +225,8 @@ function Lf:__on_open(term)
                 -- Change default_action for easier reading in the callback
                 self.action = mapping
 
-                if not self.id then
-                    local res = utils.read_file(self.tmp_id)
-                    self.id = tonumber(res)
-                end
+                local res = utils.read_file(self.tmp_id)
+                self.id = tonumber(res)
 
                 fn.system({"lf", "-remote", ("send %d open"):format(self.id)})
             end, {noremap = true, buffer = self.bufnr, desc = ("Lf %s"):format(mapping)})


### PR DESCRIPTION
Tried using mappings but found out that they only work once. This is because the function that executes the remaps isn't updating the id of the instance of LF after the first execution. This number should be updated every time as Toggleterm destroys terminal windows whenever the 'hidden' option is set to false in its configuration.