### PR TITLE
fix: check if arglist is empty before adding to vim.cmd

### DIFF
--- a/lua/lf/main.lua
+++ b/lua/lf/main.lua
@@ -277,8 +277,11 @@ function Lf:__callback(term)
             if type(stat) == "table" then
                 local fesc = fn.fnameescape(fname)
                 cmd(("%s %s"):format(self.action, fesc))
-                cmd.argadd(table.concat(self.arglist, " "))
-                cmd.argdedupe()
+                local args = table.concat(self.arglist, " ")
+                if string.len(args) > 0 then
+                  cmd.argadd(args)
+                  cmd.argdedupe()
+                end
                 self:__set_argv()
             end
         end


### PR DESCRIPTION
- Before the updates I got the following error when I was trying to open a file 
<img width="1166" alt="Screenshot 2023-09-09 at 14 28 56" src="https://github.com/lmburns/lf.nvim/assets/7600503/e0e33dd9-229b-44d5-84a0-b572bed90c49">
